### PR TITLE
support for passing client credentials as arguments

### DIFF
--- a/lib/pwinty.rb
+++ b/lib/pwinty.rb
@@ -4,19 +4,20 @@ require "rest_client"
 
 module Pwinty
 
-  def self.client
-    @@client ||= Pwinty::Client.new
+  def self.client(args={})
+    @@client ||= Pwinty::Client.new(args)
     @@client
   end
 
   class Client
-    def initialize
-      subdomain = ENV['PWINTY_PRODUCTION'] == 'true' ? "api" : "sandbox"
+    def initialize(args={})
+      options = { merchant_id: ENV['PWINTY_MERCHANT_ID'], api_key: ENV['PWINTY_API_KEY'], production: ENV['PWINTY_PRODUCTION'] == 'true' }.merge(args)
+      subdomain = options[:production] == true ? "api" : "sandbox"
       domain = "https://#{subdomain}.pwinty.com/v2.1"
 
       @pwinty = RestClient::Resource.new(domain, :headers => {
-        "X-Pwinty-MerchantId" => ENV['PWINTY_MERCHANT_ID'],
-        "X-Pwinty-REST-API-Key" => ENV['PWINTY_API_KEY'],
+        "X-Pwinty-MerchantId" => options[:merchant_id],
+        "X-Pwinty-REST-API-Key" => options[:api_key],
         'Accept' => 'application/json'
       })
     end

--- a/lib/pwinty.rb
+++ b/lib/pwinty.rb
@@ -13,7 +13,8 @@ module Pwinty
     def initialize(args={})
       options = { merchant_id: ENV['PWINTY_MERCHANT_ID'], api_key: ENV['PWINTY_API_KEY'], production: ENV['PWINTY_PRODUCTION'] == 'true' }.merge(args)
       subdomain = options[:production] == true ? "api" : "sandbox"
-      domain = "https://#{subdomain}.pwinty.com/v2.1"
+      apiVersion = options[:api_version] || 'v2.1'
+      domain = "https://#{subdomain}.pwinty.com/#{apiVersion}"
 
       @pwinty = RestClient::Resource.new(domain, :headers => {
         "X-Pwinty-MerchantId" => options[:merchant_id],

--- a/lib/pwinty.rb
+++ b/lib/pwinty.rb
@@ -10,6 +10,7 @@ module Pwinty
   end
 
   class Client
+    attr_accessor :pwinty
     def initialize(args={})
       options = { merchant_id: ENV['PWINTY_MERCHANT_ID'], api_key: ENV['PWINTY_API_KEY'], production: ENV['PWINTY_PRODUCTION'] == 'true' }.merge(args)
       subdomain = options[:production] == true ? "api" : "sandbox"
@@ -70,7 +71,11 @@ module Pwinty
       JSON.parse @pwinty["/Orders/#{orderId}/Photos"].post(args, headers)
     end
 
-    # post :add_photos, "/Orders/:orderId/Photos/Batch"
+    def add_photos(orderId, photos)
+      body = photos.is_a?(String) ? photos : photos.to_json
+      JSON.parse @pwinty["/Orders/#{orderId}/Photos/Batch"].post(body, {'Content-Type' => 'application/json'} )
+    end
+
     def delete_photo(orderId, photoId)
       JSON.parse @pwinty["/Orders/#{orderId}/Photos/#{photoId}"].delete
     end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -14,7 +14,7 @@ class TestClient < Test::Unit::TestCase
       qualityLevel: "Standard"
     }
 
-    @client = Pwinty.client
+    @client = Pwinty.client(merchant_id: ENV['PWINTY_MERCHANT_ID'], api_key: ENV['PWINTY_API_KEY'], production: false)
 
     @order_keys = %w[ id status price
                       address1 address2
@@ -42,6 +42,7 @@ class TestClient < Test::Unit::TestCase
     assert_equal body["items"].class, Array
   end
   def test_get_orders_integration
+    # NOTE: works only if you already have an order created. the first ever test run will probably fail
     body = @client.get_orders
     assert_equal body.class, Array
     assert_equal body.first.keys.sort!, @order_keys.sort!


### PR DESCRIPTION
This allows you to initialize the Pwinty::Client by passing the credentials as method arguments instead of setting environment variables:

``` ruby
    @client = Pwinty.client(merchant_id: merchant_id, api_key: api_key, production: true)
```

The change is backwards compatible as it falls back to the current ENV variables.

If found this useful when you can not access the environment variables or you're not using the ENV hash for configuration.
